### PR TITLE
refactor: remove redundant $toClass from MicroMapper, allowing improvement of generic templating

### DIFF
--- a/src/MapperInterface.php
+++ b/src/MapperInterface.php
@@ -15,6 +15,9 @@ namespace Symfonycasts\MicroMapper;
  * Also add #[AsMapper(from: Foo:class, to: Bar:class)] to each mapper class.
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
+ *
+ * @template TFrom of object
+ * @template TTo of object
  */
 interface MapperInterface
 {
@@ -24,22 +27,21 @@ interface MapperInterface
      * This method should load (e.g. from the database) or instantiate the "to object".
      * Avoid populating any properties except for an identifier.
      *
-     * @template TTo of object
-     *
-     * @param class-string<TTo> $toClass
+     * @param TFrom        $from
+     * @param array<mixed> $context
      *
      * @return TTo
      */
-    public function load(object $from, string $toClass, array $context): object;
+    public function load(object $from, array $context): object;
 
     /**
      * Populate the data onto the "to object" from the "from object".
      *
      * Receives the "to object" returned from load().
      *
-     * @template TTo of object
-     *
-     * @param TTo $to
+     * @param TFrom        $from
+     * @param TTo          $to
+     * @param array<mixed> $context
      *
      * @return TTo
      */

--- a/src/MicroMapper.php
+++ b/src/MicroMapper.php
@@ -64,7 +64,7 @@ class MicroMapper implements MicroMapperInterface
                 continue;
             }
 
-            $toObject = $mapperConfig->getMapper()->load($from, $toClass, $context);
+            $toObject = $mapperConfig->getMapper()->load($from, $context);
 
             // avoid fully populated objects if max depth is reached
             if (null === $this->maxDepth || $this->currentDepth < $this->maxDepth) {

--- a/tests/PHPStan/data/mapper.php
+++ b/tests/PHPStan/data/mapper.php
@@ -9,17 +9,18 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-use Symfonycasts\MicroMapper\MapperInterface;
+use Symfonycasts\MicroMapper\Tests\fixtures\Dinosaur;
 use Symfonycasts\MicroMapper\Tests\fixtures\DinosaurDto;
+use Symfonycasts\MicroMapper\Tests\fixtures\DinosaurToDtoMapper;
 
 use function PHPStan\Testing\assertType;
 
-function doMapperInterfaceLoad(MapperInterface $microMapper): void
+function doMapperInterfaceLoad(DinosaurToDtoMapper $dinosaurMapper, Dinosaur $dinosaur): void
 {
-    assertType(DinosaurDto::class, $microMapper->load(new \stdClass(), DinosaurDto::class));
+    assertType(DinosaurDto::class, $dinosaurMapper->load($dinosaur, []));
 }
 
-function doMapperInterfacePopulate(MapperInterface $microMapper, DinosaurDto $dto): void
+function doMapperInterfacePopulate(DinosaurToDtoMapper $dinosaurMapper, Dinosaur $dinosaur, DinosaurDto $dto): void
 {
-    assertType(DinosaurDto::class, $microMapper->populate(new \stdClass(), $dto));
+    assertType(DinosaurDto::class, $dinosaurMapper->populate($dinosaur, $dto, []));
 }

--- a/tests/fixtures/DinoRegionToDtoMapper.php
+++ b/tests/fixtures/DinoRegionToDtoMapper.php
@@ -13,6 +13,7 @@ use Symfonycasts\MicroMapper\AsMapper;
 use Symfonycasts\MicroMapper\MapperInterface;
 use Symfonycasts\MicroMapper\MicroMapperInterface;
 
+/** @implements MapperInterface<DinoRegion, DinoRegionDto> */
 #[AsMapper(from: DinoRegion::class, to: DinoRegionDto::class)]
 class DinoRegionToDtoMapper implements MapperInterface
 {
@@ -20,9 +21,9 @@ class DinoRegionToDtoMapper implements MapperInterface
     {
     }
 
-    public function load(object $from, string $toClass, array $context): object
+    public function load(object $from, array $context): object
     {
-        $dto = new $toClass();
+        $dto = new DinoRegionDto();
         $dto->id = $from->id;
 
         return $dto;
@@ -30,9 +31,6 @@ class DinoRegionToDtoMapper implements MapperInterface
 
     public function populate(object $from, object $to, array $context): object
     {
-        \assert($from instanceof DinoRegion);
-        \assert($to instanceof DinoRegionDto);
-
         $to->name = $from->name;
         $to->climate = $from->climate;
         $shallowDinosaurDtos = [];

--- a/tests/fixtures/DinosaurToDtoMapper.php
+++ b/tests/fixtures/DinosaurToDtoMapper.php
@@ -13,6 +13,7 @@ use Symfonycasts\MicroMapper\AsMapper;
 use Symfonycasts\MicroMapper\MapperInterface;
 use Symfonycasts\MicroMapper\MicroMapperInterface;
 
+/** @implements MapperInterface<Dinosaur, DinosaurDto> */
 #[AsMapper(from: Dinosaur::class, to: DinosaurDto::class)]
 class DinosaurToDtoMapper implements MapperInterface
 {
@@ -20,9 +21,9 @@ class DinosaurToDtoMapper implements MapperInterface
     {
     }
 
-    public function load(object $from, string $toClass, array $context): object
+    public function load(object $from, array $context): object
     {
-        $dto = new $toClass();
+        $dto = new DinosaurDto();
         $dto->id = $from->id;
 
         return $dto;
@@ -30,9 +31,6 @@ class DinosaurToDtoMapper implements MapperInterface
 
     public function populate(object $from, object $to, array $context): object
     {
-        \assert($from instanceof Dinosaur);
-        \assert($to instanceof DinosaurDto);
-
         $to->genus = $from->genus;
         $to->species = $from->species;
         $to->region = $this->microMapper->map($from->region, DinoRegionDto::class, [


### PR DESCRIPTION
Follows #4 

This PR removes the `$toClass` paramters from `MicroMapper::load()`, allowing for better generics templating. no stable release yet so I hope this is acceptable! 

Here is a full example with no `\assert(...)` or `@var` required on the params of `MicroMapper::load()` and `MicroMapper::populate()`: 
https://phpstan.org/r/bae2f18f-8eb5-4377-827a-0814b86bc383
thanks to @ondrejmirtes for the help!