### PR TITLE
[dx] keep tooling in one place

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "require-dev": {
         "symfony/filesystem": "^6.3|^7.0",
         "symfony/framework-bundle": "^6.3|^7.0",
-        "symfony/phpunit-bridge": "^6.3|^7.0"
+        "symfony/phpunit-bridge": "^6.3|^7.0",
+        "phpstan/phpstan": "^1.10.39"
     },
     "minimum-stability": "dev",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
     "require-dev": {
         "symfony/filesystem": "^6.3|^7.0",
         "symfony/framework-bundle": "^6.3|^7.0",
-        "symfony/phpunit-bridge": "^6.3|^7.0",
-        "phpstan/phpstan": "^1.10.39"
+        "symfony/phpunit-bridge": "^6.3|^7.0"
     },
     "minimum-stability": "dev",
     "autoload": {
@@ -29,5 +28,19 @@
         "psr-4": {
             "Symfonycasts\\MicroMapper\\Tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "tools:upgrade": [
+            "@tools:upgrade:php-cs-fixer",
+            "@tools:upgrade:phpstan"
+        ],
+        "tools:upgrade:php-cs-fixer": "composer upgrade -W -d tools/php-cs-fixer",
+        "tools:upgrade:phpstan": "composer upgrade -W -d tools/phpstan",
+        "tools:run": [
+            "@tools:run:php-cs-fixer",
+            "@tools:run:phpstan"
+        ],
+        "tools:run:php-cs-fixer": "tools/php-cs-fixer/vendor/bin/php-cs-fixer fix",
+        "tools:run:phpstan": "tools/phpstan/vendor/bin/phpstan --memory-limit=1G"
     }
 }

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,2 @@
+**/vendor
+**/composer.lock

--- a/tools/php-cs-fixer/composer.json
+++ b/tools/php-cs-fixer/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "friendsofphp/php-cs-fixer": "^3"
+    }
+}

--- a/tools/phpstan/composer.json
+++ b/tools/phpstan/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "phpstan/phpstan": "^1"
+    }
+}


### PR DESCRIPTION
- `composer tools:run` runs `php-cs-fixer` & `phpstan`
- `composer tools:run:php-cs-fixer` run only `php-cs-fixer` (works for `phpstan` as well).
- `composer tools:upgrade` upgrades / installs all of the `tools/*`
- `composer tools:upgrade:php-cs-fixer` Upgrades / installs only `php-cs-fixer` (works for `phpstan` as well)

---

This PR does _not_ remove the `phpstan/phpstan` from the main `composer.json`. PHPUnit tests are dependent on a phpstan testcase. As such, the "main" `phpstan/phpstan` in `vendor/` is used for tests & the "tools/phpstan" is used for static analysis consistent with the rest of SymfonyCasts.

We need to handle the PHPStan test case (and failures) in a separate PR