### PR TITLE
feat: Add mapMultiple method

### DIFF
--- a/src/MicroMapper.php
+++ b/src/MicroMapper.php
@@ -84,4 +84,15 @@ class MicroMapper implements MicroMapperInterface
 
         throw new \Exception(sprintf('No mapper found for %s -> %s', $from::class, $toClass));
     }
+
+    public function mapMultiple(iterable $fromIterable, string $toClass, array $context = []): array
+    {
+        $toObjects = [];
+
+        foreach ($fromIterable as $from) {
+            $toObjects[] = $this->map($from, $toClass, $context);
+        }
+
+        return $toObjects;
+    }
 }

--- a/src/MicroMapperInterface.php
+++ b/src/MicroMapperInterface.php
@@ -24,4 +24,13 @@ interface MicroMapperInterface
      * @return TTo
      */
     public function map(object $from, string $toClass, array $context = []): object;
+
+    /**
+     * @template TTo of object
+     *
+     * @param class-string<TTo> $toClass
+     *
+     * @return list<TTo>
+     */
+    public function mapMultiple(iterable $fromIterable, string $toClass, array $context = []): array;
 }

--- a/tests/Unit/MicroMapperTest.php
+++ b/tests/Unit/MicroMapperTest.php
@@ -42,17 +42,25 @@ class MicroMapperTest extends TestCase
         $this->assertSame('North America', $dto->name);
         $this->assertSame('temperate', $dto->climate);
         $this->assertCount(2, $dto->dinosaursMappedShallow);
+        $this->assertCount(2, $dto->dinosaursMultiMappedShallow);
         $this->assertCount(2, $dto->dinosaursMappedDeep);
+        $this->assertCount(2, $dto->dinosaursMultiMappedDeep);
 
         // id is mapped for both deep and shallow
         $this->assertSame(3, $dto->dinosaursMappedShallow[0]->id);
+        $this->assertSame(3, $dto->dinosaursMultiMappedShallow[0]->id);
         $this->assertSame(3, $dto->dinosaursMappedDeep[0]->id);
+        $this->assertSame(3, $dto->dinosaursMultiMappedDeep[0]->id);
         // further properties are only in the deep
         $this->assertNull($dto->dinosaursMappedShallow[0]->genus);
+        $this->assertNull($dto->dinosaursMultiMappedShallow[0]->genus);
         $this->assertSame('Velociraptor', $dto->dinosaursMappedDeep[0]->genus);
+        $this->assertSame('Velociraptor', $dto->dinosaursMultiMappedDeep[0]->genus);
         // the deep will have a region, but it will be shallow
         $this->assertSame($dto->dinosaursMappedDeep[0]->region->id, 1);
+        $this->assertSame($dto->dinosaursMultiMappedDeep[0]->region->id, 1);
         $this->assertNull($dto->dinosaursMappedDeep[0]->region->name);
+        $this->assertNull($dto->dinosaursMultiMappedDeep[0]->region->name);
 
         $reflectionObject = new \ReflectionObject($mapper);
         $objectHashesProperty = $reflectionObject->getProperty('objectHashes');

--- a/tests/fixtures/DinoRegionDto.php
+++ b/tests/fixtures/DinoRegionDto.php
@@ -22,4 +22,12 @@ class DinoRegionDto
      * @var array DinosaurDto[]
      */
     public array $dinosaursMappedDeep = [];
+    /**
+     * @var array DinosaurDto[]
+     */
+    public array $dinosaursMultiMappedShallow = [];
+    /**
+     * @var array DinosaurDto[]
+     */
+    public array $dinosaursMultiMappedDeep = [];
 }

--- a/tests/fixtures/DinoRegionToDtoMapper.php
+++ b/tests/fixtures/DinoRegionToDtoMapper.php
@@ -43,6 +43,10 @@ class DinoRegionToDtoMapper implements MapperInterface
         }
         $to->dinosaursMappedShallow = $shallowDinosaurDtos;
 
+        $to->dinosaursMultiMappedShallow = $this->microMapper->mapMultiple($from->dinosaurs, DinosaurDto::class, [
+            MicroMapperInterface::MAX_DEPTH => 0,
+        ]);
+
         $deepDinosaurDtos = [];
         foreach ($from->dinosaurs as $dino) {
             $deepDinosaurDtos[] = $this->microMapper->map($dino, DinosaurDto::class, [
@@ -50,6 +54,10 @@ class DinoRegionToDtoMapper implements MapperInterface
             ]);
         }
         $to->dinosaursMappedDeep = $deepDinosaurDtos;
+
+        $to->dinosaursMultiMappedDeep = $this->microMapper->mapMultiple($from->dinosaurs, DinosaurDto::class, [
+            MicroMapperInterface::MAX_DEPTH => 1,
+        ]);
 
         return $to;
     }


### PR DESCRIPTION
Hey,

The aim of this PR is to improve developer experience by reducing code repetition when mapping array of objects. 

Now, you have to write a lot of the following type of code:
```
        $fooDtos = [];
        foreach ($from->foos as $foo) {
            $fooDtos[] = $this->microMapper->map($foo, FooDto::class);
        }
        $to->foos = $fooDtos;
```

After this PR merges, you can still use the old method, but you can also use the following one:
```
        $to->foos = $this->microMapper->mapMultiple($from->foos, FooDto::class);
```

Hope you like it, suggestions welcomed!